### PR TITLE
feat: [CI-18178]: Add tar save and load capability with Docker archive support for buildah plugin

### DIFF
--- a/cmd/drone-docker/main.go
+++ b/cmd/drone-docker/main.go
@@ -29,7 +29,7 @@ func main() {
 		cli.BoolFlag{
 			Name:   "dry-run",
 			Usage:  "dry run disables docker push",
-			EnvVar: "PLUGIN_DRY_RUN",
+			EnvVar: "PLUGIN_DRY_RUN,PLUGIN_NO_PUSH",
 		},
 		cli.StringFlag{
 			Name:   "remote.url",
@@ -235,7 +235,7 @@ func main() {
 		cli.StringFlag{
 			Name:   "tar-path",
 			Usage:  "Path to save Docker image as tar file",
-			EnvVar: "PLUGIN_TAR_PATH",
+			EnvVar: "PLUGIN_TAR_PATH,PLUGIN_DESTINATION_TAR_PATH",
 		},
 	}
 

--- a/cmd/drone-docker/main.go
+++ b/cmd/drone-docker/main.go
@@ -237,11 +237,6 @@ func main() {
 			Usage:  "Path to save Docker image as tar file",
 			EnvVar: "PLUGIN_TAR_PATH,PLUGIN_DESTINATION_TAR_PATH",
 		},
-		cli.BoolTFlag{
-			Name:   "oci-archive",
-			Usage:  "Use OCI archive format (true=oci-archive, false=docker-archive)",
-			EnvVar: "PLUGIN_OCI_ARCHIVE",
-		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -256,7 +251,6 @@ func run(c *cli.Context) error {
 		PushOnly:      c.Bool("push-only"),
 		SourceTarPath: c.String("source-tar-path"),
 		TarPath:       c.String("tar-path"),
-		OCIArchive:    c.BoolT("oci-archive"),
 		Login: docker.Login{
 			Registry: c.String("docker.registry"),
 			Username: c.String("docker.username"),

--- a/cmd/drone-docker/main.go
+++ b/cmd/drone-docker/main.go
@@ -222,6 +222,21 @@ func main() {
 			Usage:  "User Layers",
 			EnvVar: "PLUGIN_LAYERS",
 		},
+		cli.BoolFlag{
+			Name:   "push-only",
+			Usage:  "Push existing Docker images without building",
+			EnvVar: "PLUGIN_PUSH_ONLY",
+		},
+		cli.StringFlag{
+			Name:   "source-tar-path",
+			Usage:  "Path to Docker image tar file to load and push",
+			EnvVar: "PLUGIN_SOURCE_TAR_PATH",
+		},
+		cli.StringFlag{
+			Name:   "tar-path",
+			Usage:  "Path to save Docker image as tar file",
+			EnvVar: "PLUGIN_TAR_PATH",
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -231,8 +246,11 @@ func main() {
 
 func run(c *cli.Context) error {
 	plugin := docker.Plugin{
-		Dryrun:  c.Bool("dry-run"),
-		Cleanup: c.BoolT("docker.purge"),
+		Dryrun:        c.Bool("dry-run"),
+		Cleanup:       c.BoolT("docker.purge"),
+		PushOnly:      c.Bool("push-only"),
+		SourceTarPath: c.String("source-tar-path"),
+		TarPath:       c.String("tar-path"),
 		Login: docker.Login{
 			Registry: c.String("docker.registry"),
 			Username: c.String("docker.username"),

--- a/cmd/drone-docker/main.go
+++ b/cmd/drone-docker/main.go
@@ -237,6 +237,11 @@ func main() {
 			Usage:  "Path to save Docker image as tar file",
 			EnvVar: "PLUGIN_TAR_PATH,PLUGIN_DESTINATION_TAR_PATH",
 		},
+		cli.BoolTFlag{
+			Name:   "oci-archive",
+			Usage:  "Use OCI archive format (true=oci-archive, false=docker-archive)",
+			EnvVar: "PLUGIN_OCI_ARCHIVE",
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -251,6 +256,7 @@ func run(c *cli.Context) error {
 		PushOnly:      c.Bool("push-only"),
 		SourceTarPath: c.String("source-tar-path"),
 		TarPath:       c.String("tar-path"),
+		OCIArchive:    c.BoolT("oci-archive"),
 		Login: docker.Login{
 			Registry: c.String("docker.registry"),
 			Username: c.String("docker.username"),

--- a/docker.go
+++ b/docker.go
@@ -64,7 +64,6 @@ type (
 		PushOnly      bool   // Push only mode, skips build process
 		SourceTarPath string // Path to Docker image tar file to load and push
 		TarPath       string // Path to save Docker image as tar file
-		OCIArchive    bool   // Use OCI archive format (true=oci-archive, false=docker-archive)
 	}
 )
 
@@ -138,15 +137,14 @@ func (p Plugin) Exec() error {
 
 	// If TarPath is specified and Dryrun is enabled, save the image to a tar file
 	if p.TarPath != "" && p.Dryrun && len(p.Build.Tags) > 0 {
-		// Create parent directories if they don't exist
-		dir := filepath.Dir(p.TarPath)
-		if err := os.MkdirAll(dir, 0755); err != nil {
-			return fmt.Errorf("error creating directories for tar file: %s", err)
+		// Ensure parent directories exist
+		if err := os.MkdirAll(filepath.Dir(p.TarPath), 0755); err != nil {
+			return fmt.Errorf("failed to create parent directories for tar path: %s", err)
 		}
 
 		imageToSave := fmt.Sprintf("%s:%s", p.Build.Repo, p.Build.Tags[0])
 		fmt.Println("Saving image to tar:", p.TarPath)
-		cmds = append(cmds, commandSaveTar(imageToSave, p.TarPath, p.OCIArchive))
+		cmds = append(cmds, commandSaveTar(imageToSave, p.TarPath))
 	}
 
 	if p.Cleanup {
@@ -405,7 +403,7 @@ func (p Plugin) pushOnly() error {
 		}
 
 		fmt.Println("Loading image from tar:", p.SourceTarPath)
-		loadCmd := commandLoadTar(p.SourceTarPath, p.OCIArchive)
+		loadCmd := commandLoadTar(p.SourceTarPath)
 		loadCmd.Stdout = os.Stdout
 		loadCmd.Stderr = os.Stderr
 		trace(loadCmd)
@@ -502,18 +500,11 @@ func (p Plugin) pushOnly() error {
 	return nil
 }
 
-// getArchiveFormat returns the appropriate archive format prefix based on the OCIArchive flag
-func getArchiveFormat(useOCIArchive bool) string {
-	if useOCIArchive {
-		return "oci-archive:"
-	}
-	return "docker-archive:"
-}
+
 
 // commandLoadTar creates a command to load an image from a tar file
-func commandLoadTar(tarPath string, useOCIArchive bool) *exec.Cmd {
-	archiveFormat := getArchiveFormat(useOCIArchive)
-	return exec.Command(buildahExe, "--storage-driver", "vfs", "pull", archiveFormat+tarPath)
+func commandLoadTar(tarPath string) *exec.Cmd {
+	return exec.Command(buildahExe, "--storage-driver", "vfs", "pull", "docker-archive:"+tarPath)
 }
 
 // commandImageExists creates a command to check if an image exists
@@ -522,7 +513,6 @@ func commandImageExists(image string) *exec.Cmd {
 }
 
 // commandSaveTar creates a command to save an image to a tar file
-func commandSaveTar(image string, tarPath string, useOCIArchive bool) *exec.Cmd {
-	archiveFormat := getArchiveFormat(useOCIArchive)
-	return exec.Command(buildahExe, "push", "--storage-driver", "vfs", image, archiveFormat+tarPath)
+func commandSaveTar(image string, tarPath string) *exec.Cmd {
+	return exec.Command(buildahExe, "push", "--storage-driver", "vfs", image, "docker-archive:"+tarPath)
 }

--- a/docker.go
+++ b/docker.go
@@ -1,7 +1,6 @@
 package docker
 
 import (
-	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -58,14 +57,14 @@ type (
 
 	// Plugin defines the Docker plugin parameters.
 	Plugin struct {
-		Login        Login  // Docker login configuration
-		Build        Build  // Docker build configuration
-		Dryrun       bool   // Docker push is skipped
-		Cleanup      bool   // Docker purge is enabled
-		PushOnly     bool   // Push only mode, skips build process
+		Login         Login  // Docker login configuration
+		Build         Build  // Docker build configuration
+		Dryrun        bool   // Docker push is skipped
+		Cleanup       bool   // Docker purge is enabled
+		PushOnly      bool   // Push only mode, skips build process
 		SourceTarPath string // Path to Docker image tar file to load and push
-		TarPath      string // Path to save Docker image as tar file
-		OCIArchive   bool   // Use OCI archive format (true=oci-archive, false=docker-archive)
+		TarPath       string // Path to save Docker image as tar file
+		OCIArchive    bool   // Use OCI archive format (true=oci-archive, false=docker-archive)
 	}
 )
 
@@ -420,65 +419,75 @@ func (p Plugin) pushOnly() error {
 		return fmt.Errorf("no tags specified for push")
 	}
 
-	// After loading the image from tar, find the loaded image
-	loadedImage, err := findLoadedImage(p.Build.Repo)
-	if err != nil {
-		return fmt.Errorf("failed to find loaded image: %w", err)
-	}
-	
-	// Create a map to track which images have been tagged for pushing
-	taggedImages := make(map[string]bool)
-	
-	// First check if any of our target tags already exist
-	for _, tag := range p.Build.Tags {
-		fullImage := fmt.Sprintf("%s:%s", p.Build.Repo, tag)
-		if imageExists(fullImage) {
-			taggedImages[fullImage] = true
-			continue
+	// Use the repository name as the source image name
+	sourceImageName := p.Build.Repo
+	sourceTags := p.Build.Tags
+
+	// For each source tag and target tag combination
+	taggedForPush := make(map[string]bool)
+
+	for _, sourceTag := range sourceTags {
+		sourceFullImageName := fmt.Sprintf("%s:%s", sourceImageName, sourceTag)
+
+		// Check if the source image exists in local storage
+		existsCmd := commandImageExists(sourceFullImageName)
+		existsCmd.Stdout = nil // suppress output, we only care about the exit code
+		existsCmd.Stderr = os.Stderr
+		trace(existsCmd)
+
+		if err := existsCmd.Run(); err != nil {
+			fmt.Printf("Warning: Source image %s not found\n", sourceFullImageName)
+			// Continue to the next source tag if available, otherwise return error
+			if len(sourceTags) > 1 {
+				continue
+			}
+			return fmt.Errorf("source image %s not found, cannot push", sourceFullImageName)
 		}
-	}
-	
-	// If the loaded image exists and we have tags to create
-	if loadedImage != "" {
-		// Create additional tags for any tags that don't exist
-		for _, tag := range p.Build.Tags {
-			fullImage := fmt.Sprintf("%s:%s", p.Build.Repo, tag)
-			if !taggedImages[fullImage] {
-				// Tag the loaded image with this tag
-				tagCmd := commandTag(p.Build, tag)
+
+		// For each target tag, tag and push
+		for _, targetTag := range p.Build.Tags {
+			targetFullImageName := fmt.Sprintf("%s:%s", p.Build.Repo, targetTag)
+
+			// Skip if source and target are identical
+			if sourceFullImageName == targetFullImageName {
+				fmt.Printf("Source and target image names are identical: %s\n", sourceFullImageName)
+				taggedForPush[targetFullImageName] = true
+			} else {
+				// Tag the source image with the target name
+				fmt.Printf("Tagging %s as %s\n", sourceFullImageName, targetFullImageName)
+				tagCmd := exec.Command(buildahExe, "--storage-driver", "vfs", "tag", sourceFullImageName, targetFullImageName)
 				tagCmd.Stdout = os.Stdout
 				tagCmd.Stderr = os.Stderr
 				trace(tagCmd)
 				if err := tagCmd.Run(); err == nil {
-					taggedImages[fullImage] = true
-					fmt.Printf("Created tag: %s\n", fullImage)
+					taggedForPush[targetFullImageName] = true
+				} else {
+					fmt.Printf("Warning: Failed to tag %s as %s: %s\n", sourceFullImageName, targetFullImageName, err)
 				}
 			}
 		}
 	}
-	
+
 	// If no images were tagged or found, we can't proceed
-	if len(taggedImages) == 0 {
+	if len(taggedForPush) == 0 {
 		return fmt.Errorf("no images found or tagged for repository %s, cannot push", p.Build.Repo)
 	}
 
 	var cmds []*exec.Cmd
-	
+
 	// Push all tagged images
-	for tag := range taggedImages {
+	for tag := range taggedForPush {
 		// Extract tag from the full image name
 		_, tagOnly, found := strings.Cut(tag, ":")
 		if !found {
 			continue
 		}
-		
+
 		// Push the image if not in dry-run mode
 		if !p.Dryrun {
 			cmds = append(cmds, commandPush(p.Build, tagOnly))
 		}
 	}
-
-	// Tar saving functionality is only available in the regular execution mode with dry-run enabled
 
 	// Execute all commands
 	for _, cmd := range cmds {
@@ -516,48 +525,4 @@ func commandImageExists(image string) *exec.Cmd {
 func commandSaveTar(image string, tarPath string, useOCIArchive bool) *exec.Cmd {
 	archiveFormat := getArchiveFormat(useOCIArchive)
 	return exec.Command(buildahExe, "push", "--storage-driver", "vfs", image, archiveFormat+tarPath)
-}
-
-// findLoadedImage finds the image that was loaded from the tar file by listing all images
-// and matching them against the repository name
-func findLoadedImage(repo string) (string, error) {
-	// List all images in storage
-	listCmd := exec.Command(buildahExe, "--storage-driver", "vfs", "images")
-	var output bytes.Buffer
-	listCmd.Stdout = &output
-	listCmd.Stderr = os.Stderr
-	trace(listCmd)
-	if err := listCmd.Run(); err != nil {
-		return "", fmt.Errorf("failed to list images: %w", err)
-	}
-
-	// Process the output to find a matching image
-	lines := strings.Split(strings.TrimSpace(output.String()), "\n")
-	for _, line := range lines {
-		// Skip header line
-		if strings.HasPrefix(line, "REPOSITORY") {
-			continue
-		}
-		
-		// Split the line by whitespace
-		fields := strings.Fields(line)
-		if len(fields) >= 2 {
-			// Combine repository and tag
-			fullName := fmt.Sprintf("%s:%s", fields[0], fields[1])
-			if strings.HasPrefix(fullName, repo) {
-				return fullName, nil
-			}
-		}
-	}
-
-	return "", fmt.Errorf("no matching image found for repository %s", repo)
-}
-
-// imageExists checks if an image exists in the buildah storage
-func imageExists(image string) bool {
-	existsCmd := commandImageExists(image)
-	existsCmd.Stdout = nil // suppress output, we only care about the exit code
-	existsCmd.Stderr = os.Stderr
-	trace(existsCmd)
-	return existsCmd.Run() == nil
 }

--- a/docker.go
+++ b/docker.go
@@ -57,13 +57,14 @@ type (
 
 	// Plugin defines the Docker plugin parameters.
 	Plugin struct {
-		Login         Login  // Docker login configuration
-		Build         Build  // Docker build configuration
-		Dryrun        bool   // Docker push is skipped
-		Cleanup       bool   // Docker purge is enabled
-		PushOnly      bool   // Push only mode, skips build process
+		Login        Login  // Docker login configuration
+		Build        Build  // Docker build configuration
+		Dryrun       bool   // Docker push is skipped
+		Cleanup      bool   // Docker purge is enabled
+		PushOnly     bool   // Push only mode, skips build process
 		SourceTarPath string // Path to Docker image tar file to load and push
-		TarPath       string // Path to save Docker image as tar file
+		TarPath      string // Path to save Docker image as tar file
+		OCIArchive   bool   // Use OCI archive format (true=oci-archive, false=docker-archive)
 	}
 )
 
@@ -145,7 +146,7 @@ func (p Plugin) Exec() error {
 
 		imageToSave := fmt.Sprintf("%s:%s", p.Build.Repo, p.Build.Tags[0])
 		fmt.Println("Saving image to tar:", p.TarPath)
-		cmds = append(cmds, commandSaveTar(imageToSave, p.TarPath))
+		cmds = append(cmds, commandSaveTar(imageToSave, p.TarPath, p.OCIArchive))
 	}
 
 	if p.Cleanup {
@@ -404,7 +405,7 @@ func (p Plugin) pushOnly() error {
 		}
 
 		fmt.Println("Loading image from tar:", p.SourceTarPath)
-		loadCmd := commandLoadTar(p.SourceTarPath)
+		loadCmd := commandLoadTar(p.SourceTarPath, p.OCIArchive)
 		loadCmd.Stdout = os.Stdout
 		loadCmd.Stderr = os.Stderr
 		trace(loadCmd)
@@ -466,9 +467,18 @@ func (p Plugin) pushOnly() error {
 	return nil
 }
 
+// getArchiveFormat returns the appropriate archive format prefix based on the OCIArchive flag
+func getArchiveFormat(useOCIArchive bool) string {
+	if useOCIArchive {
+		return "oci-archive:"
+	}
+	return "docker-archive:"
+}
+
 // commandLoadTar creates a command to load an image from a tar file
-func commandLoadTar(tarPath string) *exec.Cmd {
-	return exec.Command(buildahExe, "load", "--storage-driver", "vfs", "--input", tarPath)
+func commandLoadTar(tarPath string, useOCIArchive bool) *exec.Cmd {
+	archiveFormat := getArchiveFormat(useOCIArchive)
+	return exec.Command(buildahExe, "--storage-driver", "vfs", "pull", archiveFormat+tarPath)
 }
 
 // commandImageExists creates a command to check if an image exists
@@ -477,6 +487,7 @@ func commandImageExists(image string) *exec.Cmd {
 }
 
 // commandSaveTar creates a command to save an image to a tar file
-func commandSaveTar(image string, tarPath string) *exec.Cmd {
-	return exec.Command(buildahExe, "push", "--storage-driver", "vfs", image, "oci-archive:"+tarPath)
+func commandSaveTar(image string, tarPath string, useOCIArchive bool) *exec.Cmd {
+	archiveFormat := getArchiveFormat(useOCIArchive)
+	return exec.Command(buildahExe, "push", "--storage-driver", "vfs", image, archiveFormat+tarPath)
 }

--- a/docker.go
+++ b/docker.go
@@ -57,13 +57,13 @@ type (
 
 	// Plugin defines the Docker plugin parameters.
 	Plugin struct {
-		Login        Login  // Docker login configuration
-		Build        Build  // Docker build configuration
-		Dryrun       bool   // Docker push is skipped
-		Cleanup      bool   // Docker purge is enabled
-		PushOnly     bool   // Push only mode, skips build process
+		Login         Login  // Docker login configuration
+		Build         Build  // Docker build configuration
+		Dryrun        bool   // Docker push is skipped
+		Cleanup       bool   // Docker purge is enabled
+		PushOnly      bool   // Push only mode, skips build process
 		SourceTarPath string // Path to Docker image tar file to load and push
-		TarPath      string // Path to save Docker image as tar file
+		TarPath       string // Path to save Docker image as tar file
 	}
 )
 
@@ -130,29 +130,22 @@ func (p Plugin) Exec() error {
 	for _, tag := range p.Build.Tags {
 		cmds = append(cmds, commandTag(p.Build, tag)) // docker tag
 
-		if p.Dryrun == false {
+		if !p.Dryrun {
 			cmds = append(cmds, commandPush(p.Build, tag)) // docker push
 		}
 	}
 
 	// If TarPath is specified and Dryrun is enabled, save the image to a tar file
-	if p.TarPath != "" && p.Dryrun {
+	if p.TarPath != "" && p.Dryrun && len(p.Build.Tags) > 0 {
 		// Create parent directories if they don't exist
 		dir := filepath.Dir(p.TarPath)
 		if err := os.MkdirAll(dir, 0755); err != nil {
 			return fmt.Errorf("error creating directories for tar file: %s", err)
 		}
 
-		// Save the image as tar
+		imageToSave := fmt.Sprintf("%s:%s", p.Build.Repo, p.Build.Tags[0])
 		fmt.Println("Saving image to tar:", p.TarPath)
-		saveCmd := commandSaveTar(p.Build.Name, p.TarPath)
-		saveCmd.Stdout = os.Stdout
-		saveCmd.Stderr = os.Stderr
-		trace(saveCmd)
-		if err := saveCmd.Run(); err != nil {
-			return fmt.Errorf("error saving image to tar: %s", err)
-		}
-		fmt.Printf("Successfully saved image to %s\n", p.TarPath)
+		cmds = append(cmds, commandSaveTar(imageToSave, p.TarPath))
 	}
 
 	if p.Cleanup {
@@ -440,51 +433,34 @@ func (p Plugin) pushOnly() error {
 		return fmt.Errorf("source image %s not found, cannot push: %s", sourceImage, err)
 	}
 
+	var cmds []*exec.Cmd
+
 	// For each tag, tag the source image (if needed) and push
 	for _, tag := range p.Build.Tags {
 		targetImage := fmt.Sprintf("%s:%s", p.Build.Repo, tag)
-		
+
 		// Skip tagging if source and target are identical
 		if sourceImage != targetImage {
 			fmt.Printf("Tagging %s as %s\n", sourceImage, targetImage)
-			tagCmd := commandTag(p.Build, tag)
-			tagCmd.Stdout = os.Stdout
-			tagCmd.Stderr = os.Stderr
-			trace(tagCmd)
-			if err := tagCmd.Run(); err != nil {
-				return fmt.Errorf("failed to tag image %s as %s: %s", sourceImage, targetImage, err)
-			}
+			cmds = append(cmds, commandTag(p.Build, tag))
 		}
 
-		// Push the image
-		fmt.Println("Pushing image:", targetImage)
-		pushCmd := commandPush(p.Build, tag)
-		pushCmd.Stdout = os.Stdout
-		pushCmd.Stderr = os.Stderr
-		trace(pushCmd)
-		if err := pushCmd.Run(); err != nil {
-			return fmt.Errorf("failed to push image %s: %s", targetImage, err)
+		// Push the image if not in dry-run mode
+		if !p.Dryrun {
+			cmds = append(cmds, commandPush(p.Build, tag))
 		}
 	}
 
-	// If TarPath is specified and Dryrun is enabled, save the image to a tar file
-	if p.TarPath != "" && p.Dryrun {
-		// Create parent directories if they don't exist
-		dir := filepath.Dir(p.TarPath)
-		if err := os.MkdirAll(dir, 0755); err != nil {
-			return fmt.Errorf("error creating directories for tar file: %s", err)
-		}
+	// Tar saving functionality is only available in the regular execution mode with dry-run enabled
 
-		// Save the image as tar
-		fmt.Println("Saving image to tar:", p.TarPath)
-		saveCmd := commandSaveTar(sourceImage, p.TarPath)
-		saveCmd.Stdout = os.Stdout
-		saveCmd.Stderr = os.Stderr
-		trace(saveCmd)
-		if err := saveCmd.Run(); err != nil {
-			return fmt.Errorf("error saving image to tar: %s", err)
+	// Execute all commands
+	for _, cmd := range cmds {
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		trace(cmd)
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("command failed: %s", err)
 		}
-		fmt.Printf("Successfully saved image to %s\n", p.TarPath)
 	}
 
 	return nil

--- a/docker.go
+++ b/docker.go
@@ -1,6 +1,7 @@
 package docker
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -419,36 +420,61 @@ func (p Plugin) pushOnly() error {
 		return fmt.Errorf("no tags specified for push")
 	}
 
-	// Check if source image exists in local daemon before pushing
-	sourceImage := p.Build.Name
-	if sourceImage == "" {
-		sourceImage = fmt.Sprintf("%s:%s", p.Build.Repo, p.Build.Tags[0])
+	// After loading the image from tar, find the loaded image
+	loadedImage, err := findLoadedImage(p.Build.Repo)
+	if err != nil {
+		return fmt.Errorf("failed to find loaded image: %w", err)
 	}
-
-	// Verify the source image exists
-	existsCmd := commandImageExists(sourceImage)
-	existsCmd.Stdout = os.Stdout
-	existsCmd.Stderr = os.Stderr
-	trace(existsCmd)
-	if err := existsCmd.Run(); err != nil {
-		return fmt.Errorf("source image %s not found, cannot push: %s", sourceImage, err)
+	
+	// Create a map to track which images have been tagged for pushing
+	taggedImages := make(map[string]bool)
+	
+	// First check if any of our target tags already exist
+	for _, tag := range p.Build.Tags {
+		fullImage := fmt.Sprintf("%s:%s", p.Build.Repo, tag)
+		if imageExists(fullImage) {
+			taggedImages[fullImage] = true
+			continue
+		}
+	}
+	
+	// If the loaded image exists and we have tags to create
+	if loadedImage != "" {
+		// Create additional tags for any tags that don't exist
+		for _, tag := range p.Build.Tags {
+			fullImage := fmt.Sprintf("%s:%s", p.Build.Repo, tag)
+			if !taggedImages[fullImage] {
+				// Tag the loaded image with this tag
+				tagCmd := commandTag(p.Build, tag)
+				tagCmd.Stdout = os.Stdout
+				tagCmd.Stderr = os.Stderr
+				trace(tagCmd)
+				if err := tagCmd.Run(); err == nil {
+					taggedImages[fullImage] = true
+					fmt.Printf("Created tag: %s\n", fullImage)
+				}
+			}
+		}
+	}
+	
+	// If no images were tagged or found, we can't proceed
+	if len(taggedImages) == 0 {
+		return fmt.Errorf("no images found or tagged for repository %s, cannot push", p.Build.Repo)
 	}
 
 	var cmds []*exec.Cmd
-
-	// For each tag, tag the source image (if needed) and push
-	for _, tag := range p.Build.Tags {
-		targetImage := fmt.Sprintf("%s:%s", p.Build.Repo, tag)
-
-		// Skip tagging if source and target are identical
-		if sourceImage != targetImage {
-			fmt.Printf("Tagging %s as %s\n", sourceImage, targetImage)
-			cmds = append(cmds, commandTag(p.Build, tag))
+	
+	// Push all tagged images
+	for tag := range taggedImages {
+		// Extract tag from the full image name
+		_, tagOnly, found := strings.Cut(tag, ":")
+		if !found {
+			continue
 		}
-
+		
 		// Push the image if not in dry-run mode
 		if !p.Dryrun {
-			cmds = append(cmds, commandPush(p.Build, tag))
+			cmds = append(cmds, commandPush(p.Build, tagOnly))
 		}
 	}
 
@@ -490,4 +516,37 @@ func commandImageExists(image string) *exec.Cmd {
 func commandSaveTar(image string, tarPath string, useOCIArchive bool) *exec.Cmd {
 	archiveFormat := getArchiveFormat(useOCIArchive)
 	return exec.Command(buildahExe, "push", "--storage-driver", "vfs", image, archiveFormat+tarPath)
+}
+
+// findLoadedImage finds the image that was loaded from the tar file by listing all images
+// and matching them against the repository name
+func findLoadedImage(repo string) (string, error) {
+	// List all images in storage
+	listCmd := exec.Command(buildahExe, "--storage-driver", "vfs", "images", "--format", "{{.Repository}}:{{.Tag}}")
+	var output bytes.Buffer
+	listCmd.Stdout = &output
+	listCmd.Stderr = os.Stderr
+	trace(listCmd)
+	if err := listCmd.Run(); err != nil {
+		return "", fmt.Errorf("failed to list images: %w", err)
+	}
+
+	// Process the output to find a matching image
+	images := strings.Split(strings.TrimSpace(output.String()), "\n")
+	for _, img := range images {
+		if strings.HasPrefix(img, repo) {
+			return img, nil
+		}
+	}
+
+	return "", fmt.Errorf("no matching image found for repository %s", repo)
+}
+
+// imageExists checks if an image exists in the buildah storage
+func imageExists(image string) bool {
+	existsCmd := commandImageExists(image)
+	existsCmd.Stdout = nil // suppress output, we only care about the exit code
+	existsCmd.Stderr = os.Stderr
+	trace(existsCmd)
+	return existsCmd.Run() == nil
 }

--- a/docker.go
+++ b/docker.go
@@ -207,12 +207,12 @@ func commandLoginEmail(login Login) *exec.Cmd {
 
 // helper function to create the docker info command.
 func commandVersion() *exec.Cmd {
-	return exec.Command(buildahExe, "version")
+	return exec.Command(buildahExe, "--storage-driver", "vfs", "version")
 }
 
 // helper function to create the docker info command.
 func commandInfo() *exec.Cmd {
-	return exec.Command(buildahExe, "info")
+	return exec.Command(buildahExe, "--storage-driver", "vfs", "info")
 }
 
 // helper function to create the docker build command.

--- a/docker.go
+++ b/docker.go
@@ -204,9 +204,9 @@ func commandLoginEmail(login Login) *exec.Cmd {
 	)
 }
 
-// helper function to create the docker info command.
+// helper function to create the docker version command.
 func commandVersion() *exec.Cmd {
-	return exec.Command(buildahExe, "--storage-driver", "vfs", "version")
+	return exec.Command(buildahExe, "version")
 }
 
 // helper function to create the docker info command.

--- a/docker.go
+++ b/docker.go
@@ -57,10 +57,13 @@ type (
 
 	// Plugin defines the Docker plugin parameters.
 	Plugin struct {
-		Login   Login // Docker login configuration
-		Build   Build // Docker build configuration
-		Dryrun  bool  // Docker push is skipped
-		Cleanup bool  // Docker purge is enabled
+		Login        Login  // Docker login configuration
+		Build        Build  // Docker build configuration
+		Dryrun       bool   // Docker push is skipped
+		Cleanup      bool   // Docker purge is enabled
+		PushOnly     bool   // Push only mode, skips build process
+		SourceTarPath string // Path to Docker image tar file to load and push
+		TarPath      string // Path to save Docker image as tar file
 	}
 )
 
@@ -105,6 +108,11 @@ func (p Plugin) Exec() error {
 		fmt.Println("Registry credentials or Docker config not provided. Guest mode enabled.")
 	}
 
+	// Check if we're in push-only mode
+	if p.PushOnly {
+		return p.pushOnly()
+	}
+
 	// add proxy build args
 	addProxyBuildArgs(&p.Build)
 
@@ -125,6 +133,26 @@ func (p Plugin) Exec() error {
 		if p.Dryrun == false {
 			cmds = append(cmds, commandPush(p.Build, tag)) // docker push
 		}
+	}
+
+	// If TarPath is specified, save the image to a tar file
+	if p.TarPath != "" {
+		// Create parent directories if they don't exist
+		dir := filepath.Dir(p.TarPath)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return fmt.Errorf("error creating directories for tar file: %s", err)
+		}
+
+		// Save the image as tar
+		fmt.Println("Saving image to tar:", p.TarPath)
+		saveCmd := commandSaveTar(p.Build.Name, p.TarPath)
+		saveCmd.Stdout = os.Stdout
+		saveCmd.Stderr = os.Stderr
+		trace(saveCmd)
+		if err := saveCmd.Run(); err != nil {
+			return fmt.Errorf("error saving image to tar: %s", err)
+		}
+		fmt.Printf("Successfully saved image to %s\n", p.TarPath)
 	}
 
 	if p.Cleanup {
@@ -364,4 +392,115 @@ func commandRmi(tag string) *exec.Cmd {
 // tag so that it can be extracted and displayed in the logs.
 func trace(cmd *exec.Cmd) {
 	fmt.Fprintf(os.Stdout, "+ %s\n", strings.Join(cmd.Args, " "))
+}
+
+// pushOnly handles pushing images without building them
+func (p Plugin) pushOnly() error {
+	// If source tar path is provided, load the image first
+	if p.SourceTarPath != "" {
+		fileInfo, err := os.Stat(p.SourceTarPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return fmt.Errorf("source image tar file %s does not exist", p.SourceTarPath)
+			}
+			return fmt.Errorf("failed to access source image tar file: %s", err)
+		}
+
+		if !fileInfo.Mode().IsRegular() {
+			return fmt.Errorf("source image tar %s is not a regular file", p.SourceTarPath)
+		}
+
+		fmt.Println("Loading image from tar:", p.SourceTarPath)
+		loadCmd := commandLoadTar(p.SourceTarPath)
+		loadCmd.Stdout = os.Stdout
+		loadCmd.Stderr = os.Stderr
+		trace(loadCmd)
+		if err := loadCmd.Run(); err != nil {
+			return fmt.Errorf("failed to load image from tar: %s", err)
+		}
+	}
+
+	// Check for required tags
+	if len(p.Build.Tags) == 0 {
+		return fmt.Errorf("no tags specified for push")
+	}
+
+	// Check if source image exists in local daemon before pushing
+	sourceImage := p.Build.Name
+	if sourceImage == "" {
+		sourceImage = fmt.Sprintf("%s:%s", p.Build.Repo, p.Build.Tags[0])
+	}
+
+	// Verify the source image exists
+	existsCmd := commandImageExists(sourceImage)
+	existsCmd.Stdout = os.Stdout
+	existsCmd.Stderr = os.Stderr
+	trace(existsCmd)
+	if err := existsCmd.Run(); err != nil {
+		return fmt.Errorf("source image %s not found, cannot push: %s", sourceImage, err)
+	}
+
+	// For each tag, tag the source image (if needed) and push
+	for _, tag := range p.Build.Tags {
+		targetImage := fmt.Sprintf("%s:%s", p.Build.Repo, tag)
+		
+		// Skip tagging if source and target are identical
+		if sourceImage != targetImage {
+			fmt.Printf("Tagging %s as %s\n", sourceImage, targetImage)
+			tagCmd := commandTag(p.Build, tag)
+			tagCmd.Stdout = os.Stdout
+			tagCmd.Stderr = os.Stderr
+			trace(tagCmd)
+			if err := tagCmd.Run(); err != nil {
+				return fmt.Errorf("failed to tag image %s as %s: %s", sourceImage, targetImage, err)
+			}
+		}
+
+		// Push the image
+		fmt.Println("Pushing image:", targetImage)
+		pushCmd := commandPush(p.Build, tag)
+		pushCmd.Stdout = os.Stdout
+		pushCmd.Stderr = os.Stderr
+		trace(pushCmd)
+		if err := pushCmd.Run(); err != nil {
+			return fmt.Errorf("failed to push image %s: %s", targetImage, err)
+		}
+	}
+
+	// If TarPath is specified, save the image to a tar file
+	if p.TarPath != "" {
+		// Create parent directories if they don't exist
+		dir := filepath.Dir(p.TarPath)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return fmt.Errorf("error creating directories for tar file: %s", err)
+		}
+
+		// Save the image as tar
+		fmt.Println("Saving image to tar:", p.TarPath)
+		saveCmd := commandSaveTar(sourceImage, p.TarPath)
+		saveCmd.Stdout = os.Stdout
+		saveCmd.Stderr = os.Stderr
+		trace(saveCmd)
+		if err := saveCmd.Run(); err != nil {
+			return fmt.Errorf("error saving image to tar: %s", err)
+		}
+		fmt.Printf("Successfully saved image to %s\n", p.TarPath)
+	}
+
+	return nil
+}
+
+// commandLoadTar creates a command to load an image from a tar file
+func commandLoadTar(tarPath string) *exec.Cmd {
+	return exec.Command(buildahExe, "load", "--storage-driver", "vfs", "--input", tarPath)
+}
+
+// commandImageExists creates a command to check if an image exists
+func commandImageExists(image string) *exec.Cmd {
+	return exec.Command(buildahExe, "inspect", "--storage-driver", "vfs", "--type", "image", image)
+}
+
+// commandSaveTar creates a command to save an image to a tar file
+func commandSaveTar(image string, tarPath string) *exec.Cmd {
+	return exec.Command(buildahExe, "save", "--storage-driver", "vfs", "--output", tarPath, image)
 }

--- a/docker.go
+++ b/docker.go
@@ -522,7 +522,7 @@ func commandSaveTar(image string, tarPath string, useOCIArchive bool) *exec.Cmd 
 // and matching them against the repository name
 func findLoadedImage(repo string) (string, error) {
 	// List all images in storage
-	listCmd := exec.Command(buildahExe, "--storage-driver", "vfs", "images", "--format", "{{.Repository}}:{{.Tag}}")
+	listCmd := exec.Command(buildahExe, "--storage-driver", "vfs", "images")
 	var output bytes.Buffer
 	listCmd.Stdout = &output
 	listCmd.Stderr = os.Stderr
@@ -532,10 +532,21 @@ func findLoadedImage(repo string) (string, error) {
 	}
 
 	// Process the output to find a matching image
-	images := strings.Split(strings.TrimSpace(output.String()), "\n")
-	for _, img := range images {
-		if strings.HasPrefix(img, repo) {
-			return img, nil
+	lines := strings.Split(strings.TrimSpace(output.String()), "\n")
+	for _, line := range lines {
+		// Skip header line
+		if strings.HasPrefix(line, "REPOSITORY") {
+			continue
+		}
+		
+		// Split the line by whitespace
+		fields := strings.Fields(line)
+		if len(fields) >= 2 {
+			// Combine repository and tag
+			fullName := fmt.Sprintf("%s:%s", fields[0], fields[1])
+			if strings.HasPrefix(fullName, repo) {
+				return fullName, nil
+			}
 		}
 	}
 

--- a/docker.go
+++ b/docker.go
@@ -135,8 +135,8 @@ func (p Plugin) Exec() error {
 		}
 	}
 
-	// If TarPath is specified, save the image to a tar file
-	if p.TarPath != "" {
+	// If TarPath is specified and Dryrun is enabled, save the image to a tar file
+	if p.TarPath != "" && p.Dryrun {
 		// Create parent directories if they don't exist
 		dir := filepath.Dir(p.TarPath)
 		if err := os.MkdirAll(dir, 0755); err != nil {
@@ -467,8 +467,8 @@ func (p Plugin) pushOnly() error {
 		}
 	}
 
-	// If TarPath is specified, save the image to a tar file
-	if p.TarPath != "" {
+	// If TarPath is specified and Dryrun is enabled, save the image to a tar file
+	if p.TarPath != "" && p.Dryrun {
 		// Create parent directories if they don't exist
 		dir := filepath.Dir(p.TarPath)
 		if err := os.MkdirAll(dir, 0755); err != nil {
@@ -502,5 +502,5 @@ func commandImageExists(image string) *exec.Cmd {
 
 // commandSaveTar creates a command to save an image to a tar file
 func commandSaveTar(image string, tarPath string) *exec.Cmd {
-	return exec.Command(buildahExe, "save", "--storage-driver", "vfs", "--output", tarPath, image)
+	return exec.Command(buildahExe, "push", "--storage-driver", "vfs", image, "oci-archive:"+tarPath)
 }


### PR DESCRIPTION
This PR adds tar archive handling functionality to the drone-buildah plugin with the following enhancements:

Changes
- Added support for saving container images as tar archives in dry-run mode
- Implemented push-only workflow to load images from tar and push them to registries
- Added Docker archive format support for better compatibility with other tools
- Implemented robust image detection and tagging after loading from tar archives