### PR TITLE
fix: [CI-23168]: Use single-stage buildah base in plugin Dockerfiles to fix glibc/libdevmapper symbol errors

### DIFF
--- a/docker/acr/Dockerfile.linux.amd64
+++ b/docker/acr/Dockerfile.linux.amd64
@@ -1,6 +1,6 @@
 # Source for dockerfile:
 # https://github.com/containers/buildah/blob/master/docs/tutorials/05-openshift-rootless-bud.md
-FROM quay.io/buildah/stable:v1.14.8
+FROM quay.io/buildah/stable:v1.43.1
 
 RUN touch /etc/subgid /etc/subuid \
  && chmod g=u /etc/subgid /etc/subuid /etc/passwd \
@@ -16,8 +16,10 @@ RUN mkdir -p /home/build/.config/containers \
 
 USER build
 WORKDIR /home/build
+ENV STORAGE_DRIVER=vfs
+ENV BUILDAH_ISOLATION=chroot
 
-# Add plugin binary
+# Add plugin binaries
 ADD release/linux/amd64/drone-docker /bin/
 ADD release/linux/amd64/drone-acr /bin/
 ENTRYPOINT ["/bin/drone-acr"]

--- a/docker/docker/Dockerfile.linux.amd64
+++ b/docker/docker/Dockerfile.linux.amd64
@@ -1,9 +1,9 @@
-FROM quay.io/buildah/stable:v1.36.0
+FROM quay.io/buildah/stable:v1.43.1
 
 # Set up the working directory
 USER build
 WORKDIR /home/build
-RUN export STORAGE_DRIVER=vfs
+ENV STORAGE_DRIVER=vfs
 
 # Add the plugin binary
 ADD release/linux/amd64/drone-docker /bin/

--- a/docker/ecr/Dockerfile.linux.amd64
+++ b/docker/ecr/Dockerfile.linux.amd64
@@ -1,41 +1,10 @@
-FROM fedora
-
-RUN dnf -y install \
-    make \
-    golang \
-    bats \
-    btrfs-progs-devel \
-    device-mapper-devel \
-    glib2-devel \
-    gpgme-devel \
-    libassuan-devel \
-    libseccomp-devel \
-    git \
-    bzip2 \
-    go-md2man \
-    runc \
-    containers-common \
-    skopeo-containers
-
-# Workaround - the first install somehow leaves the golang in a bad state
-RUN dnf -y install golang
-
-RUN mkdir /root/buildah && \
-    cd /root/buildah && \
-    git clone https://github.com/harness/buildah.git ./src/github.com/containers/buildah
-
-RUN cd /root/buildah/src/github.com/containers/buildah && make && sudo make install
-
-
-
-FROM quay.io/buildah/stable:v1.23.0
+FROM quay.io/buildah/stable:v1.43.1
 
 USER build
 WORKDIR /home/build
-RUN export STORAGE_DRIVER=vfs
-COPY --from=0 /root/buildah/src/github.com/containers/buildah/bin/. /bin/
+ENV STORAGE_DRIVER=vfs
 
-# Add plugin binary
+# Add plugin binaries
 ADD release/linux/amd64/drone-docker /bin/
 ADD release/linux/amd64/drone-ecr /bin/
 ENTRYPOINT ["/bin/drone-ecr"]

--- a/docker/gcr/Dockerfile.linux.amd64
+++ b/docker/gcr/Dockerfile.linux.amd64
@@ -1,41 +1,10 @@
-FROM fedora
-
-RUN dnf -y install \
-    make \
-    golang \
-    bats \
-    btrfs-progs-devel \
-    device-mapper-devel \
-    glib2-devel \
-    gpgme-devel \
-    libassuan-devel \
-    libseccomp-devel \
-    git \
-    bzip2 \
-    go-md2man \
-    runc \
-    containers-common \
-    skopeo-containers
-
-# Workaround - the first install somehow leaves the golang in a bad state
-RUN dnf -y install golang
-
-RUN mkdir /root/buildah && \
-    cd /root/buildah && \
-    git clone https://github.com/harness/buildah.git ./src/github.com/containers/buildah
-
-RUN cd /root/buildah/src/github.com/containers/buildah && make && sudo make install
-
-
-
-FROM quay.io/buildah/stable:v1.23.0
+FROM quay.io/buildah/stable:v1.43.1
 
 USER build
 WORKDIR /home/build
-RUN export STORAGE_DRIVER=vfs
-COPY --from=0 /root/buildah/src/github.com/containers/buildah/bin/. /bin/
+ENV STORAGE_DRIVER=vfs
 
-# Add plugin binary
+# Add plugin binaries
 ADD release/linux/amd64/drone-docker /bin/
 ADD release/linux/amd64/drone-gcr /bin/
 ENTRYPOINT ["/bin/drone-gcr"]

--- a/docker/heroku/Dockerfile.linux.amd64
+++ b/docker/heroku/Dockerfile.linux.amd64
@@ -1,41 +1,10 @@
-FROM fedora
-
-RUN dnf -y install \
-    make \
-    golang \
-    bats \
-    btrfs-progs-devel \
-    device-mapper-devel \
-    glib2-devel \
-    gpgme-devel \
-    libassuan-devel \
-    libseccomp-devel \
-    git \
-    bzip2 \
-    go-md2man \
-    runc \
-    containers-common \
-    skopeo-containers
-
-# Workaround - the first install somehow leaves the golang in a bad state
-RUN dnf -y install golang
-
-RUN mkdir /root/buildah && \
-    cd /root/buildah && \
-    git clone https://github.com/harness/buildah.git ./src/github.com/containers/buildah
-
-RUN cd /root/buildah/src/github.com/containers/buildah && make && sudo make install
-
-
-
-FROM quay.io/buildah/stable:v1.23.0
+FROM quay.io/buildah/stable:v1.43.1
 
 USER build
 WORKDIR /home/build
-RUN export STORAGE_DRIVER=vfs
-COPY --from=0 /root/buildah/src/github.com/containers/buildah/bin/. /bin/
+ENV STORAGE_DRIVER=vfs
 
-# Add plugin binary
+# Add plugin binaries
 ADD release/linux/amd64/drone-docker /bin/
 ADD release/linux/amd64/drone-heroku /bin/
 ENTRYPOINT ["/bin/drone-heroku"]


### PR DESCRIPTION
Published `plugins/buildah-*:1.2.2` images fail to start on modern container hosts because the `buildah` binary inside cannot resolve glibc/libdevmapper symbols from the runtime stage. Customers using these plugins on EKS/GKE today hit:
  
buildah: /lib64/libdevmapper.so.1.02: version DM_1_02_197' not found 
buildah: /lib64/libc.so.6: version GLIBC_2.38' not found
buildah: /lib64/libc.so.6: version `GLIBC_2.34' not found
fatal msg="Error authenticating: exit status 1" 
  
  ### Root cause
  
  `docker/{ecr,gcr,heroku}/Dockerfile.linux.amd64` use a two-stage build with mismatched bases:
  - Stage 0: `FROM fedora` (latest) — builds `buildah` against current Fedora glibc 2.38 / libdevmapper 1.02.197
  - Stage 1: `FROM quay.io/buildah/stable:v1.23.0` (pinned to 2021) — runtime libs lag stage 0
  
  Stage 0 also clones `https://github.com/harness/buildah` (dormant since Sep 2021, no project-specific commits) and rebuilds it from source for no value — `quay.io/buildah/stable` already ships a working `buildah` binary linked
  against its own libs.
  
  `docker/{docker,acr}/Dockerfile.linux.amd64` weren't broken in the same way but were on outdated buildah bases (`v1.36.0`, `v1.14.8`) and had a no-op `RUN export STORAGE_DRIVER=vfs` (env exported in a `RUN` doesn't persist past that
  layer).
  
  ### Fix
  
  Single-stage build using the latest `quay.io/buildah/stable:v1.43.1` for both binary and runtime — guarantees the `buildah` binary and its dynamic libs come from the same image. Replace `RUN export ...` with `ENV STORAGE_DRIVER=vfs` so the value actually applies at runtime. Drop the dormant `harness/buildah` clone.
  
quay.io/buildah/stable:v1.43.1 includes all changes that were in harness/buildah main

  `acr` retains its OpenShift-style rootless setup (`subuid/subgid`, `BUILDAH_ISOLATION=chroot`, `storage.conf`) since those are intentional for restricted Pod Security environments.
  
  ### What changed per file
  
  | File | Change |
  |---|---|
  | `docker/ecr/Dockerfile.linux.amd64` | Drop 2-stage build + harness/buildah clone; single-stage `v1.43.1` |
  | `docker/gcr/Dockerfile.linux.amd64` | Same as ecr, with `drone-gcr` entrypoint |
  | `docker/heroku/Dockerfile.linux.amd64` | Same as ecr, with `drone-heroku` entrypoint |
  | `docker/docker/Dockerfile.linux.amd64` | Bump base `v1.36.0` → `v1.43.1`; `RUN export` → `ENV` |
  | `docker/acr/Dockerfile.linux.amd64` | Bump base `v1.14.8` → `v1.43.1`; preserve rootless setup; add `ENV` for `STORAGE_DRIVER`/`BUILDAH_ISOLATION` |
