### PR TITLE
fix: [CI-24655] migrate buildah-docker base to HHI buildah 1.43.2

### DIFF
--- a/docker/docker/Dockerfile.linux.amd64
+++ b/docker/docker/Dockerfile.linux.amd64
@@ -1,5 +1,10 @@
 FROM harness0.harness.io/oci/harness-beta/buildah:1.43.2
 
+# HHI buildah is minimal Alpine: prepare storage/run dirs for the non-root build user
+USER root
+RUN mkdir -p /run/containers /var/lib/containers /home/build/.local/share/containers \
+ && chown -R build:build /run/containers /var/lib/containers /home/build
+
 # Set up the working directory
 USER build
 WORKDIR /home/build

--- a/docker/docker/Dockerfile.linux.amd64
+++ b/docker/docker/Dockerfile.linux.amd64
@@ -1,10 +1,5 @@
 FROM harness0.harness.io/oci/harness-beta/buildah:1.43.2
 
-# HHI buildah is minimal Alpine: prepare storage/run dirs for the non-root build user
-USER root
-RUN mkdir -p /run/containers /var/lib/containers /home/build/.local/share/containers \
- && chown -R build:build /run/containers /var/lib/containers /home/build
-
 # Set up the working directory
 USER build
 WORKDIR /home/build

--- a/docker/docker/Dockerfile.linux.amd64
+++ b/docker/docker/Dockerfile.linux.amd64
@@ -1,4 +1,4 @@
-FROM quay.io/buildah/stable:v1.43.1
+FROM harness0.harness.io/oci/harness-beta/buildah:1.43.2
 
 # Set up the working directory
 USER build


### PR DESCRIPTION
## Summary
- Switch `plugins/buildah-docker` from `quay.io/buildah/stable:v1.43.1` (OSS, Grade F) to Harness Hardened Image `harness0.harness.io/oci/harness-beta/buildah:1.43.2` (Grade A on Prisma).
- Dockerfile layout is unchanged: `USER build`, `STORAGE_DRIVER=vfs`, `ENTRYPOINT ["/bin/drone-docker"]`.
- Scoped to `docker/docker/Dockerfile.linux.amd64` only (the image on [CI-24655](https://harness.atlassian.net/browse/CI-24655)). ECR/GCR/ACR/Heroku variants are follow-up.

## Why
HHI team published `buildah:1.43.2` for this plugin. CVEs on `plugins/buildah-docker:1.3` come from the Buildah base, not from a dind image. A dind `FROM` would drop the `buildah` CLI and break the plugin.



## Ticket
CI-24655 — parent EPIC CI-23946

[CI-24655]: https://harness.atlassian.net/browse/CI-24655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ